### PR TITLE
 remove Get Started button from targettable raycaster objects, fixes #68

### DIFF
--- a/js/load-scene.js
+++ b/js/load-scene.js
@@ -97,15 +97,19 @@ AFRAME.registerComponent('loadscene', {
       browserReposition();
     }
 
+    function onStartClick() {
+      introAudioEl.pause();
+      // container is only visible once get-started button is clicked.
+      containerEl.setAttribute('visible', true);
+      // remove button from targettable raycaster objects.
+      getStartedButton.removeAttribute('data-clickable');
+      getStartedButton.removeEventListener('click', onStartClick);
+    }
+
     // start audio after user gesture on scene.
     sceneEl.addEventListener(userPressEvent, onUserPressDown);
     sceneEl.addEventListener('loaded', onSceneLoaded);
-
-    // container is only visible once get-started button is clicked.
-    getStartedButton.addEventListener('click', function () {
-      containerEl.setAttribute('visible', true);
-      introAudioEl.pause();
-    });
+    getStartedButton.addEventListener('click', onStartClick);
 
     if (AFRAME.utils.device.isMobile() && !AFRAME.utils.device.isGearVR()){
       containerEl.setAttribute('visible', true);


### PR DESCRIPTION
Please merge #91,  #92 then this PR.

Fixes issue #68 
The problem was due to the _Get Started_ button being still visible to the raycaster.